### PR TITLE
CVX-WETH Strategy fixes [dVault]

### DIFF
--- a/contracts/integrations/curve/ICurve.sol
+++ b/contracts/integrations/curve/ICurve.sol
@@ -55,6 +55,8 @@ interface ICurve {
         uint256 min_amount,
         bool use_eth
     ) external returns (uint256);
+
+    function lp_price() external view returns (uint256);
 }
 
 interface ICurveSwapRouter {

--- a/contracts/strategies/CVXStrategy.sol
+++ b/contracts/strategies/CVXStrategy.sol
@@ -66,6 +66,10 @@ contract CVXStrategy is BaseStrategy {
         return want.balanceOf(address(this));
     }
 
+    function balanceOfCurveLPUnstaked() public view returns (uint256) {
+        return ERC20(CURVE_CVX_ETH_LP).balanceOf(address(this));
+    }
+
     function balanceOfCurveLPStaked() public view returns (uint256) {
         return
             IConvexRewards(ETH_CVX_CONVEX_CRV_REWARDS).balanceOf(address(this));
@@ -86,10 +90,7 @@ contract CVXStrategy is BaseStrategy {
     function curveLPToWant(uint256 _lpTokens) public view returns (uint256) {
         uint256 ethAmount = (
             _lpTokens > 0
-                ? ICurve(CURVE_CVX_ETH_POOL).calc_withdraw_one_coin(
-                    _lpTokens,
-                    0
-                )
+                ? (ICurve(CURVE_CVX_ETH_POOL).lp_price() * _lpTokens) / 1e18
                 : 0
         );
         return ethToWant(ethAmount);
@@ -180,7 +181,9 @@ contract CVXStrategy is BaseStrategy {
         returns (uint256 _wants)
     {
         _wants = balanceOfWant();
-        _wants += curveLPToWant(balanceOfCurveLPStaked());
+        _wants += curveLPToWant(
+            balanceOfCurveLPStaked() + balanceOfCurveLPUnstaked()
+        );
         _wants += crvToWant(balanceOfCrvRewards());
         _wants += cvxToWant(balanceOfCvxRewards());
     }
@@ -262,12 +265,16 @@ contract CVXStrategy is BaseStrategy {
                 uint256(0),
                 _pools
             );
+        }
 
+        if (address(this).balance > 0) {
             uint256[2] memory amounts = [address(this).balance, uint256(0)];
             ICurve(CURVE_CVX_ETH_POOL).add_liquidity{
                 value: address(this).balance
             }(amounts, uint256(0), true);
+        }
 
+        if (balanceOfCurveLPUnstaked() > 0) {
             require(
                 IConvexDeposit(ETH_CVX_CONVEX_DEPOSIT).depositAll(
                     uint256(64),
@@ -428,6 +435,10 @@ contract CVXStrategy is BaseStrategy {
     }
 
     function prepareMigration(address _newStrategy) internal override {
+        IConvexRewards(ETH_CVX_CONVEX_CRV_REWARDS).withdrawAndUnwrap(
+            balanceOfCurveLPStaked(),
+            true
+        );
         IERC20(CRV).safeTransfer(
             _newStrategy,
             IERC20(CRV).balanceOf(address(this))
@@ -440,7 +451,6 @@ contract CVXStrategy is BaseStrategy {
             _newStrategy,
             IERC20(CURVE_CVX_ETH_LP).balanceOf(address(this))
         );
-        _exitPosition(balanceOfCurveLPStaked());
     }
 
     function protectedTokens()

--- a/test/CVXStrategy.js
+++ b/test/CVXStrategy.js
@@ -541,6 +541,8 @@ describe("CVXStrategy", function () {
         const newStrategy = await CVXStrategy.deploy(vault.address);
         await newStrategy.deployed();
 
+        const curveLPStaked = await strategy.balanceOfCurveLPStaked();
+
         await vault["migrateStrategy(address,address)"](
             strategy.address,
             newStrategy.address
@@ -557,15 +559,22 @@ describe("CVXStrategy", function () {
         expect(Number(await newStrategy.balanceOfCurveLPStaked())).to.be.equal(
             0
         );
+        expect(Number(await want.balanceOf(newStrategy.address))).to.be.equal(
+            0
+        );
+        expect(Number(await strategy.balanceOfCurveLPUnstaked())).to.be.equal(
+            0
+        );
         expect(
-            Number(await want.balanceOf(newStrategy.address))
-        ).to.be.greaterThan(0);
+            Number(await newStrategy.balanceOfCurveLPUnstaked())
+        ).to.be.equal(Number(curveLPStaked));
 
         await newStrategy.harvest();
 
-        expect(
-            Number(await newStrategy.balanceOfCurveLPStaked())
-        ).to.be.greaterThan(0);
+        expect(Number(await strategy.balanceOfCurveLPStaked())).to.be.equal(0);
+        expect(Number(await newStrategy.balanceOfCurveLPStaked())).to.be.equal(
+            Number(curveLPStaked)
+        );
     });
 
     it("should revoke from vault", async function () {


### PR DESCRIPTION
- Use safer `lp_price` instead of `calc_withdraw_one_coin` to calculate Curve LP tokens price.
- Claiming rewards in adjusting position was added.
- Better migration logic without complete exit from the position.