### PR TITLE
Fix failing test in AuraBAL strategy

### DIFF
--- a/test/AuraBALStrategy.js
+++ b/test/AuraBALStrategy.js
@@ -368,6 +368,8 @@ describe("AuraBALStrategy", function () {
         );
         await strategy.overrideEstimatedTotalAssets(0);
         expect(Number(await strategy.estimatedTotalAssets())).to.be.equal(0);
+
+        await mine(300, { interval: 20 });
         await strategy.connect(deployer).harvest();
 
         const auraBalStakedAfter = await strategy.balanceOfStakedAuraBal();


### PR DESCRIPTION
The problem was that too small rewards were earned between two `harvest()` calls to strategy. Because we were selling too few rewards, we did not get any position in return, causing slippage protection. `mine()` call was added to simulate more rewards earnings.