### PR TITLE
[Audit] All strategies. Do not withdraw want balance already in strategy

### DIFF
--- a/contracts/strategies/AuraBALStrategy.sol
+++ b/contracts/strategies/AuraBALStrategy.sol
@@ -248,7 +248,7 @@ contract AuraBALStrategy is BaseStrategy {
             _loss = _totalDebt - _totalAssets;
         }
 
-        withdrawSome(_debtOutstanding + _profit);
+        withdrawSome(_debtOutstanding + _profit - balanceOfWant());
 
         uint256 _liquidWant = want.balanceOf(address(this));
 

--- a/contracts/strategies/AuraWETHStrategy.sol
+++ b/contracts/strategies/AuraWETHStrategy.sol
@@ -257,7 +257,7 @@ contract AuraWETHStrategy is BaseStrategy {
             _loss = _totalDebt - _totalAssets;
         }
 
-        withdrawSome(_debtOutstanding + _profit);
+        withdrawSome(_debtOutstanding + _profit - balanceOfWant());
 
         uint256 _liquidWant = want.balanceOf(address(this));
 

--- a/contracts/strategies/CVXStrategy.sol
+++ b/contracts/strategies/CVXStrategy.sol
@@ -214,7 +214,7 @@ contract CVXStrategy is BaseStrategy {
             _loss = _totalDebt - _totalAssets;
         }
 
-        _withdrawSome(_debtOutstanding + _profit);
+        _withdrawSome(_debtOutstanding + _profit - balanceOfWant());
 
         uint256 _liquidWant = want.balanceOf(address(this));
 

--- a/contracts/strategies/FXSStrategy.sol
+++ b/contracts/strategies/FXSStrategy.sol
@@ -264,7 +264,7 @@ contract FXSStrategy is BaseStrategy {
             _loss = _totalDebt - _totalAssets;
         }
 
-        _withdrawSome(_debtOutstanding + _profit);
+        _withdrawSome(_debtOutstanding + _profit - balanceOfWant());
 
         uint256 _liquidWant = want.balanceOf(address(this));
 

--- a/contracts/strategies/FraxStrategy.sol
+++ b/contracts/strategies/FraxStrategy.sol
@@ -92,7 +92,7 @@ contract FraxStrategy is BaseStrategy {
             _loss = _totalDebt - _totalAssets;
         }
 
-        withdrawSome(_debtOutstanding + _profit);
+        withdrawSome(_debtOutstanding + _profit - balanceOfWant());
 
         uint256 _liquidWant = want.balanceOf(address(this));
 

--- a/contracts/strategies/LidoAuraStrategy.sol
+++ b/contracts/strategies/LidoAuraStrategy.sol
@@ -248,7 +248,7 @@ contract LidoAuraStrategy is BaseStrategy {
             _loss = _totalDebt - _totalAssets;
         }
 
-        withdrawSome(_debtOutstanding + _profit);
+        withdrawSome(_debtOutstanding + _profit - balanceOfWant());
 
         uint256 _liquidWant = want.balanceOf(address(this));
 

--- a/contracts/strategies/RocketAuraStrategy.sol
+++ b/contracts/strategies/RocketAuraStrategy.sol
@@ -244,7 +244,7 @@ contract RocketAuraStrategy is BaseStrategy {
             _loss = _totalDebt - _totalAssets;
         }
 
-        withdrawSome(_debtOutstanding + _profit);
+        withdrawSome(_debtOutstanding + _profit - balanceOfWant());
 
         uint256 _liquidWant = want.balanceOf(address(this));
 

--- a/contracts/strategies/YCRVStrategy.sol
+++ b/contracts/strategies/YCRVStrategy.sol
@@ -213,7 +213,7 @@ contract YCRVStrategy is BaseStrategy {
             _loss = _totalDebt - _totalAssets;
         }
 
-        _withdrawSome(_debtOutstanding + _profit);
+        _withdrawSome(_debtOutstanding + _profit - balanceOfWant());
 
         uint256 _liquidWant = want.balanceOf(address(this));
 

--- a/contracts/strategies/arbitrum/GMDStrategy.sol
+++ b/contracts/strategies/arbitrum/GMDStrategy.sol
@@ -228,7 +228,7 @@ contract GMDStrategy is BaseStrategy {
             _profit = 0;
             _loss = _totalDebt - _totalAssets;
         }
-        _withdrawSome(_debtOutstanding + _profit);
+        _withdrawSome(_debtOutstanding + _profit - balanceOfWant());
 
         uint256 _liquidWant = want.balanceOf(address(this));
 

--- a/contracts/strategies/arbitrum/GMXStrategy.sol
+++ b/contracts/strategies/arbitrum/GMXStrategy.sol
@@ -249,7 +249,7 @@ contract GMXStrategy is BaseStrategy {
             _loss = _totalDebt - _totalAssets;
         }
 
-        _withdrawSome(_debtOutstanding + _profit);
+        _withdrawSome(_debtOutstanding + _profit - balanceOfWant());
 
         uint256 _liquidWant = want.balanceOf(address(this));
 

--- a/contracts/strategies/arbitrum/GNSStrategy.sol
+++ b/contracts/strategies/arbitrum/GNSStrategy.sol
@@ -243,7 +243,7 @@ contract GNSStrategy is BaseStrategy {
             _profit = 0;
             _loss = _totalDebt - _totalAssets;
         }
-        _withdrawSome(_debtOutstanding + _profit);
+        _withdrawSome(_debtOutstanding + _profit - balanceOfWant());
 
         uint256 _liquidWant = want.balanceOf(address(this));
 

--- a/contracts/strategies/arbitrum/JOEStrategy.sol
+++ b/contracts/strategies/arbitrum/JOEStrategy.sol
@@ -234,7 +234,7 @@ contract JOEStrategy is BaseStrategy {
             _loss = _totalDebt - _totalAssets;
         }
 
-        _withdrawSome(_debtOutstanding + _profit);
+        _withdrawSome(_debtOutstanding + _profit - balanceOfWant());
 
         uint256 _liquidWant = want.balanceOf(address(this));
 


### PR DESCRIPTION
Comment from auditors:
```
* Global (med, Already withdrawn want tokens are not accounted) - In prepareReturn functions, the balance of the want tokens  is not accounted for in the calculation of the amount that needed to be withdrawn in withdrawSome.
Because of this, additional tokens might be withdrawn, which will reduce earned rewards.
```