### PR TITLE
[Audit] Implement correct slippage calculation for CVX to CRV in CVXStrategy & FXSStrategy

### DIFF
--- a/contracts/strategies/CVXStrategy.sol
+++ b/contracts/strategies/CVXStrategy.sol
@@ -329,7 +329,8 @@ contract CVXStrategy is BaseStrategy {
                 [uint256(0), uint256(0), uint256(0)],
                 [uint256(0), uint256(0), uint256(0)]
             ];
-            uint256 _expected = (cvxToWant(_cvxAmount) * slippage) / 10000;
+            uint256 _expected = (CVXRewardsMath.cvxToCrv(_cvxAmount) *
+                slippage) / 10000;
             address[4] memory _pools = [
                 address(0),
                 address(0),

--- a/contracts/strategies/FXSStrategy.sol
+++ b/contracts/strategies/FXSStrategy.sol
@@ -356,7 +356,8 @@ contract FXSStrategy is BaseStrategy {
                 [uint256(0), uint256(0), uint256(0)],
                 [uint256(0), uint256(0), uint256(0)]
             ];
-            uint256 _expected = (cvxToWant(_cvxAmount) * slippage) / 10000;
+            uint256 _expected = (CVXRewardsMath.cvxToCrv(_cvxAmount) *
+                slippage) / 10000;
             address[4] memory _pools = [
                 address(0),
                 address(0),

--- a/contracts/utils/CVXRewards.sol
+++ b/contracts/utils/CVXRewards.sol
@@ -3,13 +3,18 @@
 pragma solidity ^0.8.18;
 
 import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import {OracleLibrary} from "@uniswap/v3-periphery/contracts/libraries/OracleLibrary.sol";
 
 import "../integrations/aura/ICvx.sol";
 
 /// @notice Used for calculating rewards.
 /// @dev This implementation is taken from CVX's contract (https://etherscan.io/address/0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B#code).
 library CVXRewardsMath {
+    uint32 internal constant TWAP_RANGE_SECS = 1800;
     address internal constant CVX = 0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B;
+    address internal constant CRV = 0xD533a949740bb3306d119CC777fa900bA034cd52;
+    address internal constant CVX_CRV_UNI_V3_POOL =
+        0x645c3A387b8633dF1D4D71CA4b50D27233Bcb887;
 
     using SafeMath for uint256;
 
@@ -30,5 +35,19 @@ library CVXRewardsMath {
             }
         }
         return _amount;
+    }
+
+    function cvxToCrv(uint256 cvxTokens) internal view returns (uint256) {
+        (int24 meanTick, ) = OracleLibrary.consult(
+            CVX_CRV_UNI_V3_POOL,
+            TWAP_RANGE_SECS
+        );
+        return
+            OracleLibrary.getQuoteAtTick(
+                meanTick,
+                uint128(cvxTokens),
+                CVX,
+                CRV
+            );
     }
 }


### PR DESCRIPTION
Comment from auditors:

```
* CVXStrategy L332 (med, Inaccurate slippage calculation) - _expected is supposed to reflect the minimal expected swap output in CRV, but in reality, is calculated in USDC because of cvxToWant(_cvxAmount).
The decimals value of USDC is 8, so there is no slippage protection as a result.

* Same thing for FXSStrategy
```