### PR TITLE
[Audit] L05. Default params fix

### DIFF
--- a/contracts/integrations/curve/ICurve.sol
+++ b/contracts/integrations/curve/ICurve.sol
@@ -66,7 +66,6 @@ interface ICurveSwapRouter {
         address[9] memory _route,
         uint256[3][4] memory _swap_params,
         uint256 _amount,
-        uint256 _expected,
-        address[4] memory _pools
+        uint256 _expected
     ) external payable returns (uint256);
 }

--- a/contracts/strategies/CVXStrategy.sol
+++ b/contracts/strategies/CVXStrategy.sol
@@ -274,18 +274,11 @@ contract CVXStrategy is BaseStrategy {
                 [uint256(0), uint256(0), uint256(0)],
                 [uint256(0), uint256(0), uint256(0)]
             ];
-            address[4] memory _pools = [
-                address(0),
-                address(0),
-                address(0),
-                address(0)
-            ];
             ICurveSwapRouter(CURVE_SWAP_ROUTER).exchange_multiple(
                 _route,
                 _swap_params,
                 _excessWant,
-                (_ethExpectedScaled * slippage) / 10000,
-                _pools
+                (_ethExpectedScaled * slippage) / 10000
             );
         }
 
@@ -338,19 +331,12 @@ contract CVXStrategy is BaseStrategy {
             ];
             uint256 _expected = (CVXRewardsMath.cvxToCrv(_cvxAmount) *
                 slippage) / 10000;
-            address[4] memory _pools = [
-                address(0),
-                address(0),
-                address(0),
-                address(0)
-            ];
 
             _crvAmount += ICurveSwapRouter(CURVE_SWAP_ROUTER).exchange_multiple(
                 _route,
                 _swap_params,
                 _cvxAmount,
-                _expected,
-                _pools
+                _expected
             );
         }
 
@@ -373,19 +359,12 @@ contract CVXStrategy is BaseStrategy {
                 [uint256(0), uint256(0), uint256(0)]
             ];
             uint256 _expected = (crvToWant(_crvAmount) * slippage) / 10000;
-            address[4] memory _pools = [
-                address(0),
-                address(0),
-                address(0),
-                address(0)
-            ];
 
             ICurveSwapRouter(CURVE_SWAP_ROUTER).exchange_multiple(
                 _route,
                 _swap_params,
                 _crvAmount,
-                _expected,
-                _pools
+                _expected
             );
         }
     }
@@ -431,15 +410,9 @@ contract CVXStrategy is BaseStrategy {
                 [uint256(0), uint256(0), uint256(0)]
             ];
             uint256 _expected = (ethToWant(ethAmount) * slippage) / 10000;
-            address[4] memory _pools = [
-                address(0),
-                address(0),
-                address(0),
-                address(0)
-            ];
             ICurveSwapRouter(CURVE_SWAP_ROUTER).exchange_multiple{
                 value: ethAmount
-            }(_route, _swap_params, ethAmount, _expected, _pools);
+            }(_route, _swap_params, ethAmount, _expected);
         }
     }
 

--- a/contracts/strategies/FXSStrategy.sol
+++ b/contracts/strategies/FXSStrategy.sol
@@ -365,19 +365,12 @@ contract FXSStrategy is BaseStrategy {
             ];
             uint256 _expected = (CVXRewardsMath.cvxToCrv(_cvxAmount) *
                 slippage) / 10000;
-            address[4] memory _pools = [
-                address(0),
-                address(0),
-                address(0),
-                address(0)
-            ];
 
             _crvAmount += ICurveSwapRouter(CURVE_SWAP_ROUTER).exchange_multiple(
                 _route,
                 _swap_params,
                 _cvxAmount,
-                _expected,
-                _pools
+                _expected
             );
         }
 
@@ -400,19 +393,11 @@ contract FXSStrategy is BaseStrategy {
                 [uint256(0), uint256(0), uint256(0)]
             ];
             uint256 _expected = (crvToWant(_crvAmount) * slippage) / 10000;
-            address[4] memory _pools = [
-                address(0),
-                address(0),
-                address(0),
-                address(0)
-            ];
-
             ICurveSwapRouter(CURVE_SWAP_ROUTER).exchange_multiple(
                 _route,
                 _swap_params,
                 _crvAmount,
-                _expected,
-                _pools
+                _expected
             );
         }
     }

--- a/contracts/strategies/FraxStrategy.sol
+++ b/contracts/strategies/FraxStrategy.sol
@@ -188,18 +188,11 @@ contract FraxStrategy is BaseStrategy {
             [uint256(0), uint256(0), uint256(0)],
             [uint256(0), uint256(0), uint256(0)]
         ];
-        address[4] memory _pools = [
-            address(0),
-            address(0),
-            address(0),
-            address(0)
-        ];
         ICurveSwapRouter(curveSwapRouter).exchange_multiple(
             _route,
             _swap_params,
             _frxAmount,
-            _minAmountOut,
-            _pools
+            _minAmountOut
         );
     }
 

--- a/contracts/strategies/YCRVStrategy.sol
+++ b/contracts/strategies/YCRVStrategy.sol
@@ -144,19 +144,12 @@ contract YCRVStrategy is BaseStrategy {
             [uint256(2), uint256(1), uint256(1)] // USDT -> USDC, stable swap exchange
         ];
         uint256 _expected = (yCrvToWant(yCrvBalance) * slippage) / 10000;
-        address[4] memory _pools = [
-            address(0),
-            address(0),
-            address(0),
-            address(0)
-        ];
 
         ICurveSwapRouter(CURVE_SWAP_ROUTER).exchange_multiple(
             _route,
             _swap_params,
             yCrvBalance,
-            _expected,
-            _pools
+            _expected
         );
     }
 
@@ -258,19 +251,11 @@ contract YCRVStrategy is BaseStrategy {
                 [uint256(0), uint256(1), uint256(1)] // CRV -> yCRV, stable swap exchange
             ];
             uint256 _expected = (wantToYCrv(_excessWant) * slippage) / 10000;
-            address[4] memory _pools = [
-                address(0),
-                address(0),
-                address(0),
-                address(0)
-            ];
-
             ICurveSwapRouter(CURVE_SWAP_ROUTER).exchange_multiple(
                 _route,
                 _swap_params,
                 _excessWant,
-                _expected,
-                _pools
+                _expected
             );
         }
 


### PR DESCRIPTION
Comment from auditors:
```
The _pools argument in the exchange_multiple function of the CurveSwapRouter is not required while calling. 
This argument already has a default value (array of zeroes). Thus, it can be omitted in the swaps.
```