### PR TITLE
[Audit] L12. Redundant code fix

### DIFF
--- a/contracts/strategies/FraxStrategy.sol
+++ b/contracts/strategies/FraxStrategy.sol
@@ -114,9 +114,6 @@ contract FraxStrategy is BaseStrategy {
             return;
         }
 
-        if (IERC20(frxEth).balanceOf(address(this)) > 0) {
-            _sellAllFrx();
-        }
         uint256 _wethBal = want.balanceOf(address(this));
         if (_wethBal > _debtOutstanding) {
             uint256 _excessWeth = _wethBal - _debtOutstanding;

--- a/test/FraxStrategy.js
+++ b/test/FraxStrategy.js
@@ -374,14 +374,6 @@ describe("FraxStrategy", function () {
 
         await network.provider.request({
             method: "hardhat_impersonateAccount",
-            params: [TOKENS.FRXETH.whale],
-        });
-        const FrxEth = await ethers.getContractAt(IERC20_SOURCE, TOKENS.FRXETH.address);
-        const frxWhale = await ethers.getSigner(TOKENS.FRXETH.whale);
-        await FrxEth.connect(frxWhale).transfer(strategy.address, ethers.utils.parseEther('0.0001'));
-
-        await network.provider.request({
-            method: "hardhat_impersonateAccount",
             params: [TOKENS.ETH.whale],
         });
         const ethWhale = await ethers.getSigner(TOKENS.ETH.whale);
@@ -394,18 +386,15 @@ describe("FraxStrategy", function () {
         const newStrategy = await FraxStrategy.deploy(vault.address);
         await newStrategy.deployed();
 
-        const frxethToken = await hre.ethers.getContractAt(IERC20_SOURCE, TOKENS.FRXETH.address);
         const sfrxethToken = await hre.ethers.getContractAt(IERC20_SOURCE, TOKENS.SFRXETH.address);
 
         expect(Number(await sfrxethToken.balanceOf(strategy.address))).to.be.greaterThan(0);
-        expect(Number(await frxethToken.balanceOf(strategy.address))).to.be.greaterThan(0);
         expect(Number(await ethers.provider.getBalance(strategy.address))).to.be.greaterThan(0);
 
         await vault['migrateStrategy(address,address)'](strategy.address, newStrategy.address);
 
         expect(await strategy.estimatedTotalAssets()).to.be.equal(0);
         expect(Number(await sfrxethToken.balanceOf(strategy.address))).to.be.equal(0);
-        expect(Number(await frxethToken.balanceOf(strategy.address))).to.be.equal(0);
         expect(Number(await ethers.provider.getBalance(strategy.address))).to.be.equal(0);
 
         expect(await newStrategy.estimatedTotalAssets()).to.be.closeTo(
@@ -413,13 +402,10 @@ describe("FraxStrategy", function () {
             ethers.utils.parseEther('0.0025')
         );
         expect(Number(await sfrxethToken.balanceOf(newStrategy.address))).to.be.greaterThan(0);
-        expect(Number(await frxethToken.balanceOf(newStrategy.address))).to.be.greaterThan(0);
         expect(Number(await ethers.provider.getBalance(newStrategy.address))).to.be.greaterThan(0);
 
         mine(100);
         await newStrategy.harvest();
-
-        expect(Number(await frxethToken.balanceOf(newStrategy.address))).to.be.equal(0);
 
         expect(await newStrategy.estimatedTotalAssets()).to.be.closeTo(
             ethers.utils.parseEther('1'), 


### PR DESCRIPTION
Comment from auditors:
```
In the FraxStrategy contract, the `if` statement at line 110 could be removed since the contract will not have `frxEth` tokens on its balance. 
This is so because all `frxEth` tokens are sold just after being redeemed.
```