### PR TITLE
[Audit] L15. Unused ERC20 returns fix

### DIFF
--- a/contracts/strategies/AuraBALStrategy.sol
+++ b/contracts/strategies/AuraBALStrategy.sol
@@ -60,13 +60,13 @@ contract AuraBALStrategy is BaseStrategy {
     uint256 public slippage = 9700; // 3%
 
     constructor(address _vault) BaseStrategy(_vault) {
-        want.approve(address(balancerVault), type(uint256).max);
-        ERC20(BAL).approve(address(balancerVault), type(uint256).max);
-        ERC20(AURA).approve(address(balancerVault), type(uint256).max);
-        ERC20(WETH).approve(address(balancerVault), type(uint256).max);
-        ERC20(AURA_BAL).approve(address(balancerVault), type(uint256).max);
-        ERC20(AURA_BAL).approve(AURA_BASE_REWARD, type(uint256).max);
-        ERC20(BAL).approve(AURA_BAL_DEPOSIT_WRAPPER, type(uint256).max);
+        want.safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(BAL).safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(AURA).safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(WETH).safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(AURA_BAL).safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(AURA_BAL).safeApprove(AURA_BASE_REWARD, type(uint256).max);
+        IERC20(BAL).safeApprove(AURA_BAL_DEPOSIT_WRAPPER, type(uint256).max);
     }
 
     function name() external pure override returns (string memory) {

--- a/contracts/strategies/AuraWETHStrategy.sol
+++ b/contracts/strategies/AuraWETHStrategy.sol
@@ -58,15 +58,15 @@ contract AuraWETHStrategy is BaseStrategy {
         0x1204f5060bE8b716F5A62b4Df4cE32acD01a69f5;
 
     constructor(address _vault) BaseStrategy(_vault) {
-        want.approve(address(balancerVault), type(uint256).max);
-        ERC20(BAL).approve(address(balancerVault), type(uint256).max);
-        ERC20(AURA).approve(address(balancerVault), type(uint256).max);
-        ERC20(WETH).approve(address(balancerVault), type(uint256).max);
-        ERC20(WETH_AURA_BALANCER_POOL).approve(
+        want.safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(BAL).safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(AURA).safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(WETH).safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(WETH_AURA_BALANCER_POOL).safeApprove(
             address(balancerVault),
             type(uint256).max
         );
-        ERC20(WETH_AURA_BALANCER_POOL).approve(AURA_BOOSTER, type(uint256).max);
+        IERC20(WETH_AURA_BALANCER_POOL).safeApprove(AURA_BOOSTER, type(uint256).max);
     }
 
     function name() external pure override returns (string memory) {

--- a/contracts/strategies/CVXStrategy.sol
+++ b/contracts/strategies/CVXStrategy.sol
@@ -46,14 +46,14 @@ contract CVXStrategy is BaseStrategy {
     uint256 public slippage = 9300; // 7%
 
     constructor(address _vault) BaseStrategy(_vault) {
-        want.approve(CURVE_SWAP_ROUTER, type(uint256).max);
-        ERC20(CRV).approve(CURVE_SWAP_ROUTER, type(uint256).max);
-        ERC20(CVX).approve(CURVE_SWAP_ROUTER, type(uint256).max);
-        ERC20(CURVE_CVX_ETH_LP).approve(
+        want.safeApprove(CURVE_SWAP_ROUTER, type(uint256).max);
+        IERC20(CRV).safeApprove(CURVE_SWAP_ROUTER, type(uint256).max);
+        IERC20(CVX).safeApprove(CURVE_SWAP_ROUTER, type(uint256).max);
+        IERC20(CURVE_CVX_ETH_LP).safeApprove(
             ETH_CVX_CONVEX_DEPOSIT,
             type(uint256).max
         );
-        ERC20(CURVE_CVX_ETH_LP).approve(CURVE_CVX_ETH_POOL, type(uint256).max);
+        IERC20(CURVE_CVX_ETH_LP).safeApprove(CURVE_CVX_ETH_POOL, type(uint256).max);
     }
 
     function setSlippage(uint256 _slippage) external onlyStrategist {

--- a/contracts/strategies/FXSStrategy.sol
+++ b/contracts/strategies/FXSStrategy.sol
@@ -64,14 +64,14 @@ contract FXSStrategy is BaseStrategy {
     uint256 public slippage = 9300; // 7%
 
     constructor(address _vault) BaseStrategy(_vault) {
-        ERC20(CRV).approve(CURVE_SWAP_ROUTER, type(uint256).max);
-        ERC20(CVX).approve(CURVE_SWAP_ROUTER, type(uint256).max);
-        ERC20(CURVE_FXS_LP).approve(FXS_CONVEX_DEPOSIT, type(uint256).max);
-        ERC20(CURVE_FXS_LP).approve(CURVE_FXS_POOL, type(uint256).max);
-        ERC20(FXS).approve(CURVE_FXS_POOL, type(uint256).max);
-        ERC20(FXS).approve(UNISWAP_V3_ROUTER, type(uint256).max);
+        IERC20(CRV).safeApprove(CURVE_SWAP_ROUTER, type(uint256).max);
+        IERC20(CVX).safeApprove(CURVE_SWAP_ROUTER, type(uint256).max);
+        IERC20(CURVE_FXS_LP).safeApprove(FXS_CONVEX_DEPOSIT, type(uint256).max);
+        IERC20(CURVE_FXS_LP).safeApprove(CURVE_FXS_POOL, type(uint256).max);
+        IERC20(FXS).safeApprove(CURVE_FXS_POOL, type(uint256).max);
+        IERC20(FXS).safeApprove(UNISWAP_V3_ROUTER, type(uint256).max);
 
-        want.approve(UNISWAP_V3_ROUTER, type(uint256).max);
+        want.safeApprove(UNISWAP_V3_ROUTER, type(uint256).max);
     }
 
     function setSlippage(uint256 _slippage) external onlyStrategist {

--- a/contracts/strategies/FraxStrategy.sol
+++ b/contracts/strategies/FraxStrategy.sol
@@ -33,7 +33,7 @@ contract FraxStrategy is BaseStrategy {
     uint256 public slippage = 9900; // 1%
 
     constructor(address _vault) BaseStrategy(_vault) {
-        IERC20(frxEth).approve(curveSwapRouter, type(uint256).max);
+        IERC20(frxEth).safeApprove(curveSwapRouter, type(uint256).max);
     }
 
     function name() external view override returns (string memory) {

--- a/contracts/strategies/LidoAuraStrategy.sol
+++ b/contracts/strategies/LidoAuraStrategy.sol
@@ -63,10 +63,10 @@ contract LidoAuraStrategy is BaseStrategy {
         0x59D66C58E83A26d6a0E35114323f65c3945c89c1;
 
     constructor(address _vault) BaseStrategy(_vault) {
-        want.approve(address(balancerVault), type(uint256).max);
-        IERC20(bStethStable).approve(auraBooster, type(uint256).max);
-        IERC20(auraToken).approve(address(balancerVault), type(uint256).max);
-        IERC20(balToken).approve(address(balancerVault), type(uint256).max);
+        want.safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(bStethStable).safeApprove(auraBooster, type(uint256).max);
+        IERC20(auraToken).safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(balToken).safeApprove(address(balancerVault), type(uint256).max);
     }
 
     function name() external view override returns (string memory) {

--- a/contracts/strategies/RocketAuraStrategy.sol
+++ b/contracts/strategies/RocketAuraStrategy.sol
@@ -61,10 +61,10 @@ contract RocketAuraStrategy is BaseStrategy {
     address public auraBRethStable = 0xDd1fE5AD401D4777cE89959b7fa587e569Bf125D;
 
     constructor(address _vault) BaseStrategy(_vault) {
-        want.approve(address(balancerVault), type(uint256).max);
-        IERC20(bRethStable).approve(auraBooster, type(uint256).max);
-        IERC20(auraToken).approve(address(balancerVault), type(uint256).max);
-        IERC20(balToken).approve(address(balancerVault), type(uint256).max);
+        want.safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(bRethStable).safeApprove(auraBooster, type(uint256).max);
+        IERC20(auraToken).safeApprove(address(balancerVault), type(uint256).max);
+        IERC20(balToken).safeApprove(address(balancerVault), type(uint256).max);
     }
 
     function name() external view override returns (string memory) {

--- a/contracts/strategies/YCRVStrategy.sol
+++ b/contracts/strategies/YCRVStrategy.sol
@@ -32,9 +32,9 @@ contract YCRVStrategy is BaseStrategy {
     uint256 public slippage = 9500; // 5%
 
     constructor(address _vault) BaseStrategy(_vault) {
-        want.approve(CURVE_SWAP_ROUTER, type(uint256).max);
-        ERC20(yCRV).approve(CURVE_SWAP_ROUTER, type(uint256).max);
-        ERC20(yCRV).approve(yCRVVault, type(uint256).max);
+        want.safeApprove(CURVE_SWAP_ROUTER, type(uint256).max);
+        IERC20(yCRV).safeApprove(CURVE_SWAP_ROUTER, type(uint256).max);
+        IERC20(yCRV).safeApprove(yCRVVault, type(uint256).max);
     }
 
     function setSlippage(uint256 _slippage) external onlyStrategist {

--- a/contracts/strategies/arbitrum/GMDStrategy.sol
+++ b/contracts/strategies/arbitrum/GMDStrategy.sol
@@ -38,10 +38,10 @@ contract GMDStrategy is BaseStrategy {
     uint256 public slippage = 9900; // 1%
 
     constructor(address _vault) BaseStrategy(_vault) {
-        want.approve(UNISWAP_V3_ROUTER, type(uint256).max);
-        ERC20(WETH).approve(UNISWAP_V3_ROUTER, type(uint256).max);
-        ERC20(GMD).approve(UNISWAP_V3_ROUTER, type(uint256).max);
-        ERC20(GMD).approve(GMD_POOL, type(uint256).max);
+        want.safeApprove(UNISWAP_V3_ROUTER, type(uint256).max);
+        IERC20(WETH).safeApprove(UNISWAP_V3_ROUTER, type(uint256).max);
+        IERC20(GMD).safeApprove(UNISWAP_V3_ROUTER, type(uint256).max);
+        IERC20(GMD).safeApprove(GMD_POOL, type(uint256).max);
     }
 
     function setSlippage(uint256 _slippage) external onlyStrategist {

--- a/contracts/strategies/arbitrum/GMXStrategy.sol
+++ b/contracts/strategies/arbitrum/GMXStrategy.sol
@@ -44,12 +44,12 @@ contract GMXStrategy is BaseStrategy {
     uint256 public slippage = 9500; // 5%
 
     constructor(address _vault) BaseStrategy(_vault) {
-        ERC20(GMX).approve(STAKED_GMX_TRACKER, type(uint256).max);
-        ERC20(ES_GMX).approve(STAKED_GMX_TRACKER, type(uint256).max);
-        ERC20(WETH).approve(UNISWAP_V3_ROUTER, type(uint256).max);
-        ERC20(GMX).approve(UNISWAP_V3_ROUTER, type(uint256).max);
+        IERC20(GMX).safeApprove(STAKED_GMX_TRACKER, type(uint256).max);
+        IERC20(ES_GMX).safeApprove(STAKED_GMX_TRACKER, type(uint256).max);
+        IERC20(WETH).safeApprove(UNISWAP_V3_ROUTER, type(uint256).max);
+        IERC20(GMX).safeApprove(UNISWAP_V3_ROUTER, type(uint256).max);
 
-        want.approve(UNISWAP_V3_ROUTER, type(uint256).max);
+        want.safeApprove(UNISWAP_V3_ROUTER, type(uint256).max);
     }
 
     function setSlippage(uint256 _slippage) external onlyStrategist {

--- a/contracts/strategies/arbitrum/GNSStrategy.sol
+++ b/contracts/strategies/arbitrum/GNSStrategy.sol
@@ -42,10 +42,10 @@ contract GNSStrategy is BaseStrategy {
     uint256 public slippage = 9900; // 1%
 
     constructor(address _vault) BaseStrategy(_vault) {
-        want.approve(UNISWAP_V3_ROUTER, type(uint256).max);
-        ERC20(DAI).approve(UNISWAP_V3_ROUTER, type(uint256).max);
-        ERC20(GNS).approve(UNISWAP_V3_ROUTER, type(uint256).max);
-        ERC20(GNS).approve(GNS_VAULT, type(uint256).max);
+        want.safeApprove(UNISWAP_V3_ROUTER, type(uint256).max);
+        IERC20(DAI).safeApprove(UNISWAP_V3_ROUTER, type(uint256).max);
+        IERC20(GNS).safeApprove(UNISWAP_V3_ROUTER, type(uint256).max);
+        IERC20(GNS).safeApprove(GNS_VAULT, type(uint256).max);
     }
 
     function setSlippage(uint256 _slippage) external onlyStrategist {

--- a/contracts/strategies/arbitrum/JOEStrategy.sol
+++ b/contracts/strategies/arbitrum/JOEStrategy.sol
@@ -39,10 +39,10 @@ contract JOEStrategy is BaseStrategy {
     uint256 public slippage = 9500; // 5%
 
     constructor(address _vault) BaseStrategy(_vault) {
-        ERC20(JOE).approve(STABLE_JOE_STAKING, type(uint256).max);
-        ERC20(JOE).approve(JOE_LB_ROUTER, type(uint256).max);
+        IERC20(JOE).safeApprove(STABLE_JOE_STAKING, type(uint256).max);
+        IERC20(JOE).safeApprove(JOE_LB_ROUTER, type(uint256).max);
 
-        want.approve(JOE_LB_ROUTER, type(uint256).max);
+        want.safeApprove(JOE_LB_ROUTER, type(uint256).max);
     }
 
     function setRewardToken(address _rewardToken) external onlyStrategist {


### PR DESCRIPTION
Comment from auditors:
```
The return values of ERC20 `approve` calls are not handled throughout the codebase in the project.
```