### PR TITLE
[Audit] M06. Incorrect earned CVX calculations

### DIFF
--- a/contracts/utils/CVXRewards.sol
+++ b/contracts/utils/CVXRewards.sol
@@ -33,8 +33,11 @@ library CVXRewardsMath {
             if (_amount > amtTillMax) {
                 _amount = amtTillMax;
             }
+
+            return _amount;
         }
-        return _amount;
+
+        return 0;
     }
 
     function cvxToCrv(uint256 cvxTokens) internal view returns (uint256) {


### PR DESCRIPTION
Comment from auditors:

```
The convertCrvToCvx function of the CVXRewardsMath library calculates the reward in 
CVX tokens relative to CRV as the mint function of CVX token. The convertCrvToCvx function returns the 
amount after if (cliff < totalCliffs). If totalSupply reaches the maximum, the whole amount is returned, 
whereas 0 should be returned.
```