### PR TITLE
[Audit] L06. FXS rewards are not transferred upon migration

### DIFF
--- a/contracts/strategies/FXSStrategy.sol
+++ b/contracts/strategies/FXSStrategy.sol
@@ -266,7 +266,7 @@ contract FXSStrategy is BaseStrategy {
 
         uint256 _liquidWant = balanceOfWant();
         uint256 _amountNeeded = _debtOutstanding + _profit;
-        if(_liquidWant <= _amountNeeded){
+        if (_liquidWant <= _amountNeeded) {
             _withdrawSome(_amountNeeded - _liquidWant);
             _liquidWant = balanceOfWant();
         }
@@ -492,6 +492,10 @@ contract FXSStrategy is BaseStrategy {
             true
         );
         IERC20(CRV).safeTransfer(
+            _newStrategy,
+            IERC20(CRV).balanceOf(address(this))
+        );
+        IERC20(FXS).safeTransfer(
             _newStrategy,
             IERC20(CRV).balanceOf(address(this))
         );


### PR DESCRIPTION
Comment from auditors:

```
FXS rewards should be withdrawn along with CRV и CVX tokens in the
prepareMigration function of the FXSStrategy contract.
```