### PR TITLE
Code audit. L17. Gas usage fix

### DIFF
--- a/abi/AuraBALStrategy.json
+++ b/abi/AuraBALStrategy.json
@@ -15,7 +15,7 @@
   "event UpdatedStrategist(address)",
   "function apiVersion() pure returns (string)",
   "function auraBalToWant(uint256) view returns (uint256)",
-  "function auraRewards() view returns (uint256)",
+  "function auraRewards(uint256) view returns (uint256)",
   "function auraToWant(uint256) view returns (uint256)",
   "function balRewards() view returns (uint256)",
   "function balToWant(uint256) view returns (uint256)",

--- a/abi/AuraWETHStrategy.json
+++ b/abi/AuraWETHStrategy.json
@@ -17,7 +17,7 @@
   "function AURA_WETH_REWARDS() view returns (address)",
   "function apiVersion() pure returns (string)",
   "function auraBptToBpt(uint256) pure returns (uint256)",
-  "function auraRewards() view returns (uint256)",
+  "function auraRewards(uint256) view returns (uint256)",
   "function auraToWant(uint256) view returns (uint256)",
   "function balRewards() view returns (uint256)",
   "function balToWant(uint256) view returns (uint256)",

--- a/abi/LidoAuraStrategy.json
+++ b/abi/LidoAuraStrategy.json
@@ -17,7 +17,7 @@
   "function apiVersion() pure returns (string)",
   "function auraBStethStable() view returns (address)",
   "function auraBptToBpt(uint256) pure returns (uint256)",
-  "function auraRewards() view returns (uint256)",
+  "function auraRewards(uint256) view returns (uint256)",
   "function auraToWant(uint256) view returns (uint256)",
   "function balRewards() view returns (uint256)",
   "function balToWant(uint256) view returns (uint256)",

--- a/abi/RocketAuraStrategy.json
+++ b/abi/RocketAuraStrategy.json
@@ -17,7 +17,7 @@
   "function apiVersion() pure returns (string)",
   "function auraBRethStable() view returns (address)",
   "function auraBptToBpt(uint256) pure returns (uint256)",
-  "function auraRewards() view returns (uint256)",
+  "function auraRewards(uint256) view returns (uint256)",
   "function auraToWant(uint256) view returns (uint256)",
   "function balRewards() view returns (uint256)",
   "function balToWant(uint256) view returns (uint256)",

--- a/contracts/strategies/AuraBALStrategy.sol
+++ b/contracts/strategies/AuraBALStrategy.sol
@@ -94,8 +94,8 @@ contract AuraBALStrategy is BaseStrategy {
         return IERC20(AURA_BAL).balanceOf(address(this));
     }
 
-    function auraRewards() public view returns (uint256) {
-        return AuraRewardsMath.convertCrvToCvx(balRewards());
+    function auraRewards(uint256 balTokens) public view returns (uint256) {
+        return AuraRewardsMath.convertCrvToCvx(balTokens);
     }
 
     function balanceOfAura() public view returns (uint256) {
@@ -170,12 +170,13 @@ contract AuraBALStrategy is BaseStrategy {
         uint256 auraBalTokens = balanceOfStakedAuraBal() +
             balanceOfUnstakedAuraBal();
         _wants += auraBalToWant(auraBalTokens);
-        uint256 balTokens = balRewards() + balanceOfBal();
+        uint256 balRewardTokens = balRewards();
+        uint256 balTokens = balRewardTokens + balanceOfBal();
         if (balTokens > 0) {
             _wants += balToWant(balTokens);
         }
 
-        uint256 auraTokens = auraRewards() + balanceOfAura();
+        uint256 auraTokens = auraRewards(balRewardTokens) + balanceOfAura();
         if (auraTokens > 0) {
             _wants += auraToWant(auraTokens);
         }
@@ -461,8 +462,9 @@ contract AuraBALStrategy is BaseStrategy {
             return;
         }
 
-        uint256 balTokens = balRewards() + ERC20(BAL).balanceOf(address(this));
-        uint256 auraTokens = auraRewards() +
+        uint256 balRewardTokens = balRewards();
+        uint256 balTokens = balRewardTokens + ERC20(BAL).balanceOf(address(this));
+        uint256 auraTokens = auraRewards(balRewardTokens) +
             ERC20(AURA).balanceOf(address(this));
         uint256 rewardsTotal = balToWant(balTokens) + auraToWant(auraTokens);
 

--- a/contracts/strategies/AuraWETHStrategy.sol
+++ b/contracts/strategies/AuraWETHStrategy.sol
@@ -104,8 +104,8 @@ contract AuraWETHStrategy is BaseStrategy {
         return IERC20(AURA_WETH_REWARDS).balanceOf(address(this));
     }
 
-    function auraRewards() public view returns (uint256) {
-        return AuraRewardsMath.convertCrvToCvx(balRewards());
+    function auraRewards(uint256 balTokens) public view returns (uint256) {
+        return AuraRewardsMath.convertCrvToCvx(balTokens);
     }
 
     function auraBptToBpt(uint _amountAuraBpt) public pure returns (uint256) {
@@ -174,12 +174,13 @@ contract AuraWETHStrategy is BaseStrategy {
         uint256 bptTokens = balanceOfUnstakedBpt() +
             auraBptToBpt(balanceOfAuraBpt());
         _wants += bptToWant(bptTokens);
-        uint256 balTokens = balRewards() + ERC20(BAL).balanceOf(address(this));
+        uint256 balRewardTokens = balRewards();
+        uint256 balTokens = balRewardTokens + ERC20(BAL).balanceOf(address(this));
         if (balTokens > 0) {
             _wants += balToWant(balTokens);
         }
 
-        uint256 auraTokens = auraRewards() +
+        uint256 auraTokens = auraRewards(balRewardTokens) +
             ERC20(AURA).balanceOf(address(this));
         if (auraTokens > 0) {
             _wants += auraToWant(auraTokens);
@@ -487,8 +488,9 @@ contract AuraWETHStrategy is BaseStrategy {
             return;
         }
 
-        uint256 balTokens = balRewards() + ERC20(BAL).balanceOf(address(this));
-        uint256 auraTokens = auraRewards() +
+        uint256 balRewardTokens = balRewards();
+        uint256 balTokens = balRewardTokens + ERC20(BAL).balanceOf(address(this));
+        uint256 auraTokens = auraRewards(balRewardTokens) +
             ERC20(AURA).balanceOf(address(this));
         uint256 rewardsTotal = balToWant(balTokens) + auraToWant(auraTokens);
 

--- a/contracts/strategies/LidoAuraStrategy.sol
+++ b/contracts/strategies/LidoAuraStrategy.sol
@@ -108,8 +108,8 @@ contract LidoAuraStrategy is BaseStrategy {
         return IConvexRewards(auraBStethStable).earned(address(this));
     }
 
-    function auraRewards() public view returns (uint256) {
-        return AuraRewardsMath.convertCrvToCvx(balRewards());
+    function auraRewards(uint256 balTokens) public view returns (uint256) {
+        return AuraRewardsMath.convertCrvToCvx(balTokens);
     }
 
     function auraBptToBpt(uint _amountAuraBpt) public pure returns (uint256) {
@@ -134,7 +134,7 @@ contract LidoAuraStrategy is BaseStrategy {
             _wants += balToWant(balTokens);
         }
 
-        uint256 auraTokens = auraRewards();
+        uint256 auraTokens = auraRewards(balTokens);
         if (auraTokens > 0) {
             _wants += auraToWant(auraTokens);
         }
@@ -375,8 +375,9 @@ contract LidoAuraStrategy is BaseStrategy {
     }
 
     function withdrawSome(uint256 _amountNeeded) internal {
-        uint256 balTokens = balRewards() + balanceOfBal();
-        uint256 auraTokens = auraRewards() + balanceOfAura();
+        uint256 balRewardsTokens = balRewards();
+        uint256 balTokens = balRewardsTokens + balanceOfBal();
+        uint256 auraTokens = auraRewards(balRewardsTokens) + balanceOfAura();
         uint256 rewardsTotal = balToWant(balTokens) + auraToWant(auraTokens);
 
         if (rewardsTotal >= _amountNeeded) {

--- a/contracts/strategies/RocketAuraStrategy.sol
+++ b/contracts/strategies/RocketAuraStrategy.sol
@@ -106,8 +106,8 @@ contract RocketAuraStrategy is BaseStrategy {
         return IConvexRewards(auraBRethStable).earned(address(this));
     }
 
-    function auraRewards() public view returns (uint256) {
-        return AuraRewardsMath.convertCrvToCvx(balRewards());
+    function auraRewards(uint256 balTokens) public view returns (uint256) {
+        return AuraRewardsMath.convertCrvToCvx(balTokens);
     }
 
     function auraBptToBpt(uint _amountAuraBpt) public pure returns (uint256) {
@@ -125,12 +125,13 @@ contract RocketAuraStrategy is BaseStrategy {
         uint256 bptTokens = balanceOfUnstakedBpt() +
             auraBptToBpt(balanceOfAuraBpt());
         _wants += bptToWant(bptTokens);
-        uint256 balTokens = balRewards() + balanceOfBal();
+        uint256 balRewardTokens = balRewards();
+        uint256 balTokens = balRewardTokens + balanceOfBal();
         if (balTokens > 0) {
             _wants += balToWant(balTokens);
         }
 
-        uint256 auraTokens = auraRewards() + balanceOfAura();
+        uint256 auraTokens = auraRewards(balRewardTokens) + balanceOfAura();
         if (auraTokens > 0) {
             _wants += auraToWant(auraTokens);
         }
@@ -372,8 +373,9 @@ contract RocketAuraStrategy is BaseStrategy {
     }
 
     function withdrawSome(uint256 _amountNeeded) internal {
-        uint256 balTokens = balRewards() + balanceOfBal();
-        uint256 auraTokens = auraRewards() + balanceOfAura();
+        uint256 balRewardTokens = balRewards();
+        uint256 balTokens = balRewardTokens + balanceOfBal();
+        uint256 auraTokens = auraRewards(balRewardTokens) + balanceOfAura();
         uint256 rewardsTotal = balToWant(balTokens) + auraToWant(auraTokens);
 
         if (rewardsTotal >= _amountNeeded) {

--- a/test/AuraBALStrategy.js
+++ b/test/AuraBALStrategy.js
@@ -679,6 +679,6 @@ describe("AuraBALStrategy", function () {
         await mine(300, { interval: 20 });
 
         expect(Number(await strategy.balRewards())).to.be.greaterThan(0);
-        expect(Number(await strategy.auraRewards())).to.be.greaterThan(0);
+        expect(Number(await strategy.auraRewards(await strategy.balRewards()))).to.be.greaterThan(0);
     });
 });

--- a/test/AuraWETHStrategy.js
+++ b/test/AuraWETHStrategy.js
@@ -671,7 +671,7 @@ describe("AuraWETHStrategy", function () {
         await mine(300, { interval: 20 });
 
         expect(Number(await strategy.balRewards())).to.be.greaterThan(0);
-        expect(Number(await strategy.auraRewards())).to.be.greaterThan(0);
+        expect(Number(await strategy.auraRewards(await strategy.balRewards()))).to.be.greaterThan(0);
     });
 
     it("should change AURA PID and AURA rewards", async function () {


### PR DESCRIPTION
Comment from auditors:
```
The `auraRewards()` depends on `balRewards()`, which calls `IConvexRewards(AURA_BASE_REWARD).earned()`. Through the codebase, there are places where `balRewards()` will be called twice (the first time to get `balRewards()` and second time, to calculate `auraRewards()`). 
We recommend saving the result of `balRewards()` and using it for calculation without calling the second time to save gas. The same issue is present in the strategies with `CRV` and `CVX` contracts.
```