### PR TITLE
[Audit] L13. Redundant code fix

### DIFF
--- a/contracts/strategies/CVXStrategy.sol
+++ b/contracts/strategies/CVXStrategy.sol
@@ -484,6 +484,10 @@ contract CVXStrategy is BaseStrategy {
             _newStrategy,
             IERC20(CURVE_CVX_ETH_LP).balanceOf(address(this))
         );
+        uint256 ethBal = address(this).balance;
+        if (ethBal > 0) {
+            payable(_newStrategy).transfer(ethBal);
+        }
     }
 
     function protectedTokens()

--- a/contracts/strategies/FraxStrategy.sol
+++ b/contracts/strategies/FraxStrategy.sol
@@ -52,7 +52,6 @@ contract FraxStrategy is BaseStrategy {
         returns (uint256 _wants)
     {
         _wants = balanceOfWant();
-        _wants += address(this).balance;
         _wants += sfrxToWant(IERC20(sfrxEth).balanceOf(address(this)));
         _wants += frxToWant(IERC20(frxEth).balanceOf(address(this)));
         return _wants;


### PR DESCRIPTION
Comment from auditors:
```
In the **FraxStrategy** contract in `estimatedTotalAssets` and `prepareMigration` functions, the logic related to native ether could be removed. 
The contract will not be holding any native ether since all ether is deposited just after the `WETH.withdraw` call is done.
```