### PR TITLE
[Audit] M02. Already withdrawn want tokens are not accounted

### DIFF
--- a/contracts/strategies/AuraBALStrategy.sol
+++ b/contracts/strategies/AuraBALStrategy.sol
@@ -488,13 +488,11 @@ contract AuraBALStrategy is BaseStrategy {
         uint256 _amountNeeded
     ) internal override returns (uint256 _liquidatedAmount, uint256 _loss) {
         uint256 _wantBal = want.balanceOf(address(this));
-        if (_wantBal >= _amountNeeded) {
-            return (_amountNeeded, 0);
+        if(_wantBal < _amountNeeded){
+            withdrawSome(_amountNeeded - _wantBal);
+            _wantBal = balanceOfWant();
         }
 
-        withdrawSome(_amountNeeded);
-
-        _wantBal = want.balanceOf(address(this));
         if (_amountNeeded > _wantBal) {
             _liquidatedAmount = _wantBal;
             _loss = _amountNeeded - _wantBal;

--- a/contracts/strategies/AuraWETHStrategy.sol
+++ b/contracts/strategies/AuraWETHStrategy.sol
@@ -514,13 +514,11 @@ contract AuraWETHStrategy is BaseStrategy {
         uint256 _amountNeeded
     ) internal override returns (uint256 _liquidatedAmount, uint256 _loss) {
         uint256 _wantBal = want.balanceOf(address(this));
-        if (_wantBal >= _amountNeeded) {
-            return (_amountNeeded, 0);
+        if(_wantBal < _amountNeeded){
+            withdrawSome(_amountNeeded - _wantBal);
+            _wantBal = balanceOfWant();
         }
 
-        withdrawSome(_amountNeeded);
-
-        _wantBal = want.balanceOf(address(this));
         if (_amountNeeded > _wantBal) {
             _liquidatedAmount = _wantBal;
             _loss = _amountNeeded - _wantBal;

--- a/contracts/strategies/FraxStrategy.sol
+++ b/contracts/strategies/FraxStrategy.sol
@@ -140,13 +140,11 @@ contract FraxStrategy is BaseStrategy {
         uint256 _amountNeeded
     ) internal override returns (uint256 _liquidatedAmount, uint256 _loss) {
         uint256 _wethBal = want.balanceOf(address(this));
-        if (_wethBal >= _amountNeeded) {
-            return (_amountNeeded, 0);
+        if(_wethBal < _amountNeeded){
+            withdrawSome(_amountNeeded - _wethBal);
+            _wethBal = balanceOfWant();
         }
 
-        withdrawSome(_amountNeeded);
-
-        _wethBal = want.balanceOf(address(this));
         if (_amountNeeded > _wethBal) {
             _liquidatedAmount = _wethBal;
             _loss = _amountNeeded - _wethBal;

--- a/contracts/strategies/LidoAuraStrategy.sol
+++ b/contracts/strategies/LidoAuraStrategy.sol
@@ -398,13 +398,11 @@ contract LidoAuraStrategy is BaseStrategy {
         uint256 _amountNeeded
     ) internal override returns (uint256 _liquidatedAmount, uint256 _loss) {
         uint256 _wethBal = want.balanceOf(address(this));
-        if (_wethBal >= _amountNeeded) {
-            return (_amountNeeded, 0);
+        if(_wethBal < _amountNeeded){
+            withdrawSome(_amountNeeded - _wethBal);
+            _wethBal = balanceOfWant();
         }
 
-        withdrawSome(_amountNeeded);
-
-        _wethBal = want.balanceOf(address(this));
         if (_amountNeeded > _wethBal) {
             _liquidatedAmount = _wethBal;
             _loss = _amountNeeded - _wethBal;


### PR DESCRIPTION
Comment from auditors:
```
In the `liquidatePosition` function of the **FraxStrategy, LidoAuraStrategy, AuraWETHStrategy**, and **AuraBALStrategy** contracts, the balance of the `want` tokens is not taken into account when calculating the amount that needs to be withdrawn in the `withdrawSome` function. 
Currently, these contracts will not withdraw from the positions if the strategy has enough `want` tokens. However, if there are insufficient `want` tokens, the strategies will withdraw the entire `_amountNeeded` from the positions. It is possible to partially cover the `_amountNeeded` with the available `want` balance, which could potentially increase the strategy's profitability as fewer tokens are withdrawn from the positions.
```