### PR TITLE
[Audit] L10. Onchain price evaluation

### DIFF
--- a/contracts/integrations/balancer/IBalancerV2Vault.sol
+++ b/contracts/integrations/balancer/IBalancerV2Vault.sol
@@ -60,6 +60,21 @@ interface IBalancerV2Vault {
         bool toInternalBalance;
     }
 
+    enum UserBalanceOpKind {
+        DEPOSIT_INTERNAL,
+        WITHDRAW_INTERNAL,
+        TRANSFER_INTERNAL,
+        TRANSFER_EXTERNAL
+    }
+
+    struct UserBalanceOp {
+        UserBalanceOpKind kind;
+        address asset;
+        uint256 amount;
+        address sender;
+        address payable recipient;
+    }
+
     function getPool(bytes32 poolId) external view returns (address pool);
 
     function swap(
@@ -110,4 +125,6 @@ interface IBalancerV2Vault {
         IAsset[] memory assets,
         FundManagement memory funds
     ) external returns (int256[] memory assetDeltas);
+
+    function manageUserBalance(UserBalanceOp[] memory ops) external payable;
 }

--- a/test/AuraWETHStrategy.js
+++ b/test/AuraWETHStrategy.js
@@ -671,7 +671,9 @@ describe("AuraWETHStrategy", function () {
         await mine(300, { interval: 20 });
 
         expect(Number(await strategy.balRewards())).to.be.greaterThan(0);
-        expect(Number(await strategy.auraRewards(await strategy.balRewards()))).to.be.greaterThan(0);
+        expect(
+            Number(await strategy.auraRewards(await strategy.balRewards()))
+        ).to.be.greaterThan(0);
     });
 
     it("should change AURA PID and AURA rewards", async function () {


### PR DESCRIPTION
Comment from auditors:

```
In AuraWETHStrategy.sol, the getBptPrice function uses onchain balances price evaluation. 
Balancer documentation notes that the contract should check for the vault reentrancy 
since this price formula might be manipulated. Despite the fact that we did not find any 
attacks on the current strategy, we still recommend checking for the reentrancy.
```